### PR TITLE
When using frameworks it won't be the mainbundle

### DIFF
--- a/SDK/OpenWebRTCUtils.m
+++ b/SDK/OpenWebRTCUtils.m
@@ -42,7 +42,7 @@ static JSContext *_context;
         if (_context == nil) {
             _context = [[JSContext alloc] init];
 
-            NSString *path = [[NSBundle mainBundle] pathForResource:@"sdp" ofType:@"js"];
+            NSString *path = [[NSBundle bundleForClass:[self class]] pathForResource:@"sdp" ofType:@"js"];
             if (path) {
                 NSError *error;
                 NSURL *fileURL = [NSURL fileURLWithPath:path];


### PR DESCRIPTION
When using this SDK as a framework (required for when using Swift cocoapods) then the sdp.js file won't be in the mainbundele. It will be in the same bundle as the current class.