### PR TITLE
Fix frozen previews on iOS after hangup

### DIFF
--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -983,10 +983,6 @@ static void reset()
         renderers = NULL;
     }
 
-    // Don't unregister the views to prevent frozen video after hangup
-    //owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
-    //owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
-
     if (transport_agent) {
         media_sessions = g_object_steal_data(G_OBJECT(transport_agent), "media-sessions");
         for (item = media_sessions; item; item = item->next) {

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -983,8 +983,9 @@ static void reset()
         renderers = NULL;
     }
 
-    owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
-    owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
+    // Don't unregister the views to prevent frozen video after hangup
+    //owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
+    //owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
 
     if (transport_agent) {
         media_sessions = g_object_steal_data(G_OBJECT(transport_agent), "media-sessions");


### PR DESCRIPTION
Fix/workaround for https://github.com/EricssonResearch/openwebrtc-examples/issues/106 by not unregistering the video-views (self and remote) after hangup. 