### PR TITLE
add unregister functions for selfview / remoteview

### DIFF
--- a/SDK/OpenWebRTCNativeHandler.h
+++ b/SDK/OpenWebRTCNativeHandler.h
@@ -53,9 +53,9 @@
 - (instancetype)initWithDelegate:(id <OpenWebRTCNativeHandlerDelegate>)delegate;
 
 - (void)setSelfView:(OpenWebRTCVideoView *)selfView;
-- (void)removeSelfView:(OpenWebRTCVideoView *)selfView;
+- (void)removeSelfView;
 - (void)setRemoteView:(OpenWebRTCVideoView *)remoteView;
-- (void)removeRemoteView:(OpenWebRTCVideoView *)remoteView;
+- (void)removeRemoteView;
 - (void)addSTUNServerWithAddress:(NSString *)address port:(NSInteger)port;
 - (void)addTURNServerWithAddress:(NSString *)address port:(NSInteger)port username:(NSString *)username password:(NSString *)password isTCP:(BOOL)isTCP;
 

--- a/SDK/OpenWebRTCNativeHandler.h
+++ b/SDK/OpenWebRTCNativeHandler.h
@@ -53,7 +53,9 @@
 - (instancetype)initWithDelegate:(id <OpenWebRTCNativeHandlerDelegate>)delegate;
 
 - (void)setSelfView:(OpenWebRTCVideoView *)selfView;
+- (void)removeSelfView:(OpenWebRTCVideoView *)selfView;
 - (void)setRemoteView:(OpenWebRTCVideoView *)remoteView;
+- (void)removeRemoteView:(OpenWebRTCVideoView *)remoteView;
 - (void)addSTUNServerWithAddress:(NSString *)address port:(NSInteger)port;
 - (void)addTURNServerWithAddress:(NSString *)address port:(NSInteger)port username:(NSString *)username password:(NSString *)password isTCP:(BOOL)isTCP;
 

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -148,7 +148,7 @@ static OpenWebRTCNativeHandler *staticSelf;
     owr_window_registry_register(owr_window_registry_get(), SELF_VIEW_TAG, (__bridge gpointer)(selfView));
 }
 
-- (void) removeSelfView:(OpenWebRTCVideoView *) selfView
+- (void) removeSelfView
 {
     if(_selfView) {
         owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
@@ -161,7 +161,7 @@ static OpenWebRTCNativeHandler *staticSelf;
     owr_window_registry_register(owr_window_registry_get(), REMOTE_VIEW_TAG, (__bridge gpointer)(remoteView));
 }
 
-- (void)removeRemoteView:(OpenWebRTCVideoView *)remoteView
+- (void)removeRemoteView
 {
     if(_remoteView) {
         owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -148,10 +148,24 @@ static OpenWebRTCNativeHandler *staticSelf;
     owr_window_registry_register(owr_window_registry_get(), SELF_VIEW_TAG, (__bridge gpointer)(selfView));
 }
 
+- (void) removeSelfView:(OpenWebRTCVideoView *) selfView
+{
+    if(_selfView) {
+        owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
+    }
+}
+
 - (void)setRemoteView:(OpenWebRTCVideoView *)remoteView
 {
     _remoteView = remoteView;
     owr_window_registry_register(owr_window_registry_get(), REMOTE_VIEW_TAG, (__bridge gpointer)(remoteView));
+}
+
+- (void)removeRemoteView:(OpenWebRTCVideoView *)remoteView
+{
+    if(_remoteView) {
+        owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
+    }
 }
 
 - (void)addSTUNServerWithAddress:(NSString *)address port:(NSInteger)port

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -148,9 +148,9 @@ static OpenWebRTCNativeHandler *staticSelf;
     owr_window_registry_register(owr_window_registry_get(), SELF_VIEW_TAG, (__bridge gpointer)(selfView));
 }
 
-- (void) removeSelfView
+- (void)removeSelfView
 {
-    if(_selfView) {
+    if (_selfView) {
         owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
     }
 }
@@ -163,7 +163,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 
 - (void)removeRemoteView
 {
-    if(_remoteView) {
+    if (_remoteView) {
         owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
     }
 }


### PR DESCRIPTION
I saw the commit log (da1015e65e6f52a5df589143268a6a4d9bc2185a) which had removed the 
owr_window_registry_unregister (selfview/remoteview) from code. 

But actually, we do need there two unregister functions. 
If we don't unregister that. 
We will get following warning message and then it will cause App crash. 

    ** (<unknown>:5655): WARNING **: Tag 'self-view' has already been registered for another window handle


I think we should provide two unregister functions for developers for flexible using. 



Test Environment : 
- iDevice : iPhone 6 - iOS 9.1 
- XCode : Version 7.1.1 (7B1005)
