### PR TITLE
implement candidateGenerate function and bring local candidate string back

### DIFF
--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -152,6 +152,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 {
     if (_selfView) {
         owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
+        _selfView = nil;
     }
 }
 
@@ -165,6 +166,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 {
     if (_remoteView) {
         owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
+        _remoteView = nil;
     }
 }
 

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -148,9 +148,9 @@ static OpenWebRTCNativeHandler *staticSelf;
     owr_window_registry_register(owr_window_registry_get(), SELF_VIEW_TAG, (__bridge gpointer)(selfView));
 }
 
-- (void) removeSelfView
+- (void)removeSelfView
 {
-    if(_selfView) {
+    if (_selfView) {
         owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
     }
 }
@@ -163,7 +163,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 
 - (void)removeRemoteView
 {
-    if(_remoteView) {
+    if (_remoteView) {
         owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
     }
 }

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -753,8 +753,6 @@ static void got_candidate(GObject *media_session, OwrCandidate *candidate, gpoin
 
     if (staticSelf.delegate) {
         [staticSelf.delegate candidateGenerate:candidateString];
-        // TODO: Send candidates.
-        NSLog(@"############################# TODO: Send candidate to other side (ICE trickle).");
     }
 }
 


### PR DESCRIPTION
Hi, 

I found this function, got_candidate, collect all local candidates and put them into a candidate list. 
And then put into a SDP offer. 
But in some applications, we do need to send each candidate respectively, and you also provide 
this protocol, candidateGenerate. 

So, I implement this and send local candidate back to application for flexible using. 
Please check, and thanks. 
