### PR TITLE
Add TrickleICE Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The entry point class for Native app developement is `OpenWebRTCNativeHandler`:
 - (instancetype)initWithDelegate:(id <OpenWebRTCNativeHandlerDelegate>)delegate;
 
 - (void)setSelfView:(OpenWebRTCVideoView *)selfView;
+- (void)removeSelfView;
 - (void)setRemoteView:(OpenWebRTCVideoView *)remoteView;
+- (void)removeRemoteView;
 - (void)addSTUNServerWithAddress:(NSString *)address port:(NSInteger)port;
 - (void)addTURNServerWithAddress:(NSString *)address port:(NSInteger)port username:(NSString *)username password:(NSString *)password isTCP:(BOOL)isTCP;
 

--- a/SDK/OpenWebRTCNativeHandler.h
+++ b/SDK/OpenWebRTCNativeHandler.h
@@ -62,6 +62,7 @@
 - (void)startGetCaptureSourcesForAudio:(BOOL)audio video:(BOOL)video;
 - (void)initiateCall;
 - (void)terminateCall;
+- (void)enableTrickleICE;
 
 - (void)handleOfferReceived:(NSString *)offer;
 - (void)handleAnswerReceived:(NSString *)answer;

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -152,6 +152,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 {
     if (_selfView) {
         owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
+        _selfView = nil;
     }
 }
 
@@ -165,6 +166,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 {
     if (_remoteView) {
         owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
+        _remoteView = nil;
     }
 }
 

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -68,7 +68,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 @property (nonatomic, strong) NSMutableArray *helperServers;
 @property (nonatomic, strong) NSMutableArray *remoteCandidatesCache;
 @property (nonatomic, strong) NSMutableArray *localSourceArray;
-@property (nonatomic, assign) BOOL is_trickleICE_enabled;
+@property (nonatomic, assign) BOOL isTrickleICEEnabled;
 
 @end
 
@@ -173,7 +173,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 
 - (void)enableTrickleICE
 {
-    _is_trickleICE_enabled = YES;
+    _isTrickleICEEnabled = YES;
 }
 
 - (void)addSTUNServerWithAddress:(NSString *)address port:(NSInteger)port
@@ -1062,7 +1062,7 @@ static void send_offer()
         g_list_free(candidates);
 
         ice[@"candidates"] = candidatesArray;
-        ice[@"iceOptions"] = @{@"trickle":[NSNumber numberWithBool:staticSelf.is_trickleICE_enabled]};
+        ice[@"iceOptions"] = @{@"trickle":[NSNumber numberWithBool:staticSelf.isTrickleICEEnabled]};
         mediaDescription[@"ice"] = ice;
 
         NSMutableDictionary *dtls = [NSMutableDictionary dictionary];

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -68,6 +68,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 @property (nonatomic, strong) NSMutableArray *helperServers;
 @property (nonatomic, strong) NSMutableArray *remoteCandidatesCache;
 @property (nonatomic, strong) NSMutableArray *localSourceArray;
+@property (nonatomic, assign) BOOL is_trickleICE_enabled;
 
 @end
 
@@ -168,6 +169,11 @@ static OpenWebRTCNativeHandler *staticSelf;
         owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
         _remoteView = nil;
     }
+}
+
+- (void)enableTrickleICE
+{
+    _is_trickleICE_enabled = YES;
 }
 
 - (void)addSTUNServerWithAddress:(NSString *)address port:(NSInteger)port
@@ -1056,6 +1062,7 @@ static void send_offer()
         g_list_free(candidates);
 
         ice[@"candidates"] = candidatesArray;
+        ice[@"iceOptions"] = @{@"trickle":[NSNumber numberWithBool:staticSelf.is_trickleICE_enabled]};
         mediaDescription[@"ice"] = ice;
 
         NSMutableDictionary *dtls = [NSMutableDictionary dictionary];
@@ -1069,9 +1076,7 @@ static void send_offer()
         g_free(fingerprint);
         g_free(ice_password);
         g_free(ice_ufrag);
-        //g_free(encoding_name);
-        //g_free(media_type);
-
+        
         [mediaDescriptions addObject:mediaDescription];
     }
     

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -148,9 +148,9 @@ static OpenWebRTCNativeHandler *staticSelf;
     owr_window_registry_register(owr_window_registry_get(), SELF_VIEW_TAG, (__bridge gpointer)(selfView));
 }
 
-- (void) removeSelfView
+- (void)removeSelfView
 {
-    if(_selfView) {
+    if (_selfView) {
         owr_window_registry_unregister(owr_window_registry_get(), SELF_VIEW_TAG);
     }
 }
@@ -163,7 +163,7 @@ static OpenWebRTCNativeHandler *staticSelf;
 
 - (void)removeRemoteView
 {
-    if(_remoteView) {
+    if (_remoteView) {
         owr_window_registry_unregister(owr_window_registry_get(), REMOTE_VIEW_TAG);
     }
 }

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -753,8 +753,6 @@ static void got_candidate(GObject *media_session, OwrCandidate *candidate, gpoin
 
     if (staticSelf.delegate) {
         [staticSelf.delegate candidateGenerate:candidateString];
-        // TODO: Send candidates.
-        NSLog(@"############################# TODO: Send candidate to other side (ICE trickle).");
     }
 }
 


### PR DESCRIPTION
Hello, 

According to https://github.com/EricssonResearch/openwebrtc/blob/master/bridge/client/sdp.js ,
sdp.js supports ice-options:trickle, 
but iOS SDK could not enable that, even a developer send an ice-candidate immediately. 
So, Add a function to enable that. 
In new SDP offer, you will see this line to indicate that we need to enable trickle ice feature. 
```
\na=ice-options:trickle
```


Please help to review this, thanks a lot. 