### PR TITLE
remove initialize method, fix warning message 'explicit call to +init…

### DIFF
--- a/SDK/OpenWebRTC.h
+++ b/SDK/OpenWebRTC.h
@@ -37,10 +37,4 @@
 
 @interface OpenWebRTC : NSObject
 
-/**
- *  Initializes OpenWebRTC. Should preferably be run inside your AppDelegate's 
- *  initialize method to ensure OpenWebRTC has enough time to set things up.
- */
-+ (void)initialize;
-
 @end

--- a/SDK/OpenWebRTC.h
+++ b/SDK/OpenWebRTC.h
@@ -37,4 +37,10 @@
 
 @interface OpenWebRTC : NSObject
 
+/**
+ *  Initializes OpenWebRTC. Should preferably be run inside your AppDelegate's 
+ *  initialize method to ensure OpenWebRTC has enough time to set things up.
+ */
++ (void)initOpenWebRTC;
+
 @end

--- a/SDK/OpenWebRTC.m
+++ b/SDK/OpenWebRTC.m
@@ -38,7 +38,7 @@
     return nil;
 }
 
-+ (void)initialize
++ (void)initOpenWebRTC
 {
     if (self == [OpenWebRTC class]) {
         static BOOL isInitialized = NO;


### PR DESCRIPTION
When we use following code in AppDelegate 
+ (void)initialize
{
    if (self == [AppDelegate class]) {
        [OpenWebRTC initialize];
    }
}


Xcode will warn you that "explicit call to +initialize results in duplicate call to +initialize"
Cause OpenWebRTC inherits from NSObject, 
So I think we don't create a class method with the same method name "initialize" in OpenWebRTC.h 
just need to override it in OpenWebRTC.m


