### PR TITLE
Include both SDP and JSON in signaling messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The entry point class for Native app developement is `OpenWebRTCNativeHandler`:
 
 - (void)answerGenerated:(NSDictionary *)answer;
 - (void)offerGenerated:(NSDictionary *)offer;
-- (void)candidateGenerate:(NSString *)candidate;
+- (void)candidateGenerated:(NSDictionary *)candidate;
 
 /**
  * Format of sources:

--- a/SDK/OpenWebRTCNativeHandler.h
+++ b/SDK/OpenWebRTCNativeHandler.h
@@ -34,7 +34,7 @@
 
 - (void)answerGenerated:(NSDictionary *)answer;
 - (void)offerGenerated:(NSDictionary *)offer;
-- (void)candidateGenerate:(NSString *)candidate;
+- (void)candidateGenerated:(NSDictionary *)candidate;
 
 /**
  * Format of sources:

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -702,7 +702,7 @@ static gboolean should_send_answer()
 static gboolean can_send_offer()
 {
     NSLog(@">>>>>>>>>>>>>>>>>>>>>>>>>> can_send_offer");
-    GObject *media_session;
+    GObject *media_session = NULL;
     GList *media_sessions, *item;
 
     media_sessions = g_object_get_data(G_OBJECT(transport_agent), "media-sessions");

--- a/SDK/OpenWebRTCNativeHandler.m
+++ b/SDK/OpenWebRTCNativeHandler.m
@@ -562,16 +562,21 @@ static OpenWebRTCNativeHandler *staticSelf;
     return remote_candidate;
 }
 
+NSDictionary *
+candidate_description_form_sdp_string (NSString *candidate)
+{
+    NSString *fakeSDP = [NSString stringWithFormat:@"m=application 0 NONE\r\na=%@\r\n", candidate];
+    NSDictionary *candidateInfo = [OpenWebRTCUtils parseSDPFromString:fakeSDP];
+    return candidateInfo[@"mediaDescriptions"][0][@"ice"][@"candidates"][0];
+}
+
 - (void)handleRemoteCandidateReceived:(NSDictionary *)remoteCandidate
 {
     NSMutableDictionary *candidate = [NSMutableDictionary dictionaryWithDictionary:remoteCandidate];
 
-    if (!candidate[@"candidateDescription"]) {
-        NSString *fakeSDP = [NSString stringWithFormat:@"m=application 0 NONE\r\na=%@\r\n", candidate[@"candidate"]];
-        NSDictionary *candidateInfo = [OpenWebRTCUtils parseSDPFromString:fakeSDP];
-        NSDictionary *candidateDescription = candidateInfo[@"mediaDescriptions"][0][@"ice"][@"candidates"][0];
-        candidate[@"candidateDescription"] = candidateDescription;
-    }
+    if (!candidate[@"candidateDescription"])
+        candidate[@"candidateDescription"] = \
+            candidate_description_form_sdp_string (candidate[@"candidate"]);
 
     if (candidate && candidate[@"candidateDescription"]) {
         gint index;


### PR DESCRIPTION
This pull request unbreaks interop with test-client.[c|py] by including both JSON and SDP in signaling messages. So now the iOS SDK can parse both JSON and SDP in incoming messages and always sends both in outgoing messages.

As previously discussed this is a short term solution to have all demos working again. The signaling code across the SDKs and demos could use a larger rework.
